### PR TITLE
Fix incompatibility&crash when installing Marello alongside OroCommerce

### DIFF
--- a/src/Marello/Bundle/RuleBundle/Resources/config/oro/entity.yml
+++ b/src/Marello/Bundle/RuleBundle/Resources/config/oro/entity.yml
@@ -1,0 +1,5 @@
+oro_entity:
+    entity_aliases:
+        Marello\Bundle\RuleBundle\Entity\Rule:
+            alias:        marello_rule
+            plural_alias: marello_rules


### PR DESCRIPTION
Fix incompatibility & crash when installing Marello EE alongside OroCommerce EE

`Oro\Bundle\RuleBundle\Entity\Rule` and `Marello\Bundle\RuleBundle\Entity\Rule` produces the same entity aliases if not manually specified in config files.