### PR TITLE
Returns : add control on shipment existence before render form

### DIFF
--- a/src/Marello/Bundle/ReturnBundle/Controller/ReturnController.php
+++ b/src/Marello/Bundle/ReturnBundle/Controller/ReturnController.php
@@ -9,6 +9,7 @@ use Oro\Bundle\SecurityBundle\Annotation\AclAncestor;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration as Config;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
+use Oro\Bundle\SecurityBundle\Exception\ForbiddenException;
 
 class ReturnController extends Controller
 {
@@ -38,40 +39,44 @@ class ReturnController extends Controller
         $return->setOrder($order);
         $return->setSalesChannel($order->getSalesChannel());
 
-        $form = $this->createForm('marello_return', $return);
-        $form->handleRequest($request);
+        if(null !== $order->getShipment()) {
+            $form = $this->createForm('marello_return', $return);
+            $form->handleRequest($request);
 
-        if ($form->isSubmitted() && $form->isValid()) {
-            $manager = $this->getDoctrine()->getManager();
+            if ($form->isSubmitted() && $form->isValid()) {
+                $manager = $this->getDoctrine()->getManager();
 
-            $manager->persist($return);
-            $manager->flush();
-            $this->get('session')->getFlashBag()->add(
-                'success',
-                $this->get('translator')->trans('marello.return.returnentity.messages.success.returnentity.saved')
-            );
-            return $this->get('oro_ui.router')->redirectAfterSave(
-                [
-                    'route'      => 'marello_return_return_update',
-                    'parameters' => [
-                        'id'                      => $return->getId(),
-                        '_enableContentProviders' => 'mainMenu'
-                    ]
-                ],
-                [
-                    'route'      => 'marello_return_return_view',
-                    'parameters' => [
-                        'id'                      => $return->getId(),
-                        '_enableContentProviders' => 'mainMenu'
-                    ]
-                ],
-                $return
-            );
+                $manager->persist($return);
+                $manager->flush();
+                $this->get('session')->getFlashBag()->add(
+                    'success',
+                    $this->get('translator')->trans('marello.return.returnentity.messages.success.returnentity.saved')
+                );
+                return $this->get('oro_ui.router')->redirectAfterSave(
+                    [
+                        'route' => 'marello_return_return_update',
+                        'parameters' => [
+                            'id' => $return->getId(),
+                            '_enableContentProviders' => 'mainMenu'
+                        ]
+                    ],
+                    [
+                        'route' => 'marello_return_return_view',
+                        'parameters' => [
+                            'id' => $return->getId(),
+                            '_enableContentProviders' => 'mainMenu'
+                        ]
+                    ],
+                    $return
+                );
+            }
+
+            return [
+                'form' => $form->createView(),
+            ];
+        } else {
+            throw new ForbiddenException('An order without shipment cannot be returned');
         }
-
-        return [
-            'form' => $form->createView(),
-        ];
     }
 
     /**


### PR DESCRIPTION
This PR fixes an issue regarding Marello Returns.
**Before :** 
An order whatever its step in the workflow could have a return.
Even if the `create return` button is unavailable, in order view, someone who knows the create return url, can access the form and create a return for any orders.

**After :**
If an user tries to access the return creation form for an order that have no shipment, an error is thrown.

![image](https://user-images.githubusercontent.com/17732411/45248469-4b10ac80-b311-11e8-93fc-27ce450d9446.png)

![image](https://user-images.githubusercontent.com/17732411/45248496-9aef7380-b311-11e8-8256-e2be43f725bf.png)
