### PR TITLE
Possibility to reset the Shipment

### DIFF
--- a/src/Marello/Bundle/ShippingBundle/Entity/HasShipmentTrait.php
+++ b/src/Marello/Bundle/ShippingBundle/Entity/HasShipmentTrait.php
@@ -20,11 +20,11 @@ trait HasShipmentTrait
     }
 
     /**
-     * @param Shipment $shipment
+     * @param null|Shipment $shipment
      *
      * @return $this
      */
-    public function setShipment(Shipment $shipment)
+    public function setShipment(?Shipment $shipment = null)
     {
         $this->shipment = $shipment;
 

--- a/src/Marello/Bundle/ShippingBundle/Integration/ShippingAwareInterface.php
+++ b/src/Marello/Bundle/ShippingBundle/Integration/ShippingAwareInterface.php
@@ -8,5 +8,5 @@ interface ShippingAwareInterface
 {
     public function getShipment();
 
-    public function setShipment(Shipment $shipment);
+    public function setShipment(?Shipment $shipment);
 }


### PR DESCRIPTION
Useful if you need to remove a Shipment from an Order.

The field is nullable in both table (marello_return_return and marello_order_order) so we should be able to set NULL.
