### PR TITLE
prevent to add multiple time the same SKU in order

### DIFF
--- a/src/Marello/Bundle/OrderBundle/Provider/OrderItem/OrderItemFormChangesProvider.php
+++ b/src/Marello/Bundle/OrderBundle/Provider/OrderItem/OrderItemFormChangesProvider.php
@@ -72,6 +72,18 @@ class OrderItemFormChangesProvider extends AbstractOrderItemFormChangesProvider
                     }
                 }
             }
+
+            $duplicatedItems = array_diff_assoc($productIds, array_unique($productIds));
+            if(!empty($duplicatedItems)) {
+                foreach ($duplicatedItems as $duplicatedItem)
+                {
+                    $itemResult[self::IDENTIFIER_PREFIX . $duplicatedItem] = [
+                        'message' => $this->translator
+                            ->trans('marello.order.orderitem.messages.product_duplicated_in_order'),
+                    ];
+                }
+            }
+
             $result[self::ITEMS_FIELD] = $itemResult;
             $context->setResult($result);
         }

--- a/src/Marello/Bundle/OrderBundle/Resources/translations/messages.en.yml
+++ b/src/Marello/Bundle/OrderBundle/Resources/translations/messages.en.yml
@@ -97,6 +97,7 @@ marello:
 
             messages:
                 product_not_salable:    Product cannot be sold in the chosen Sales Channel
+                product_duplicated_in_order:    Product is duplicated in the order
 
         # Customer Entity
         customer:


### PR DESCRIPTION
This PR prevents duplication of item in the order creation process.

If an order has multiple times the same SKU, it will lead to an error on packing slip generation, which will contain only one line of this SKU.

To prevent this behavior, each time form-change is triggered, we check that there is no duplicates, else, we alert the user.

![image](https://user-images.githubusercontent.com/17732411/50908283-b1c1e600-1429-11e9-9b2c-809b7296309c.png)
