### PR TITLE
Non expected return type (interface non-implemented)

### DIFF
--- a/src/Marello/Bundle/TaxBundle/Matcher/CompositeTaxRuleMatcher.php
+++ b/src/Marello/Bundle/TaxBundle/Matcher/CompositeTaxRuleMatcher.php
@@ -32,7 +32,7 @@ class CompositeTaxRuleMatcher implements TaxRuleMatcherInterface
     public function match(AbstractAddress $address = null, array $taxCodes)
     {
         if (null === $address || null === $address->getCountry() || 0 === count($taxCodes)) {
-            return [];
+            return null;
         }
 
         $cacheKey = $this->getCacheKey($address, $taxCodes);


### PR DESCRIPTION
Fix tax rule resolver when no address nor country has been given.

As described in TaxRuleMatcherInterface , method match must return null or TaxRule. Here it was returning array. Interface is not well implementated - causing errors afterward.