### PR TITLE
Specify full namespaces in Doctrine DiscriminatorMap for AbstractInvoice and AbstractInvoiceItem

### DIFF
--- a/src/Marello/Bundle/InvoiceBundle/Entity/AbstractInvoice.php
+++ b/src/Marello/Bundle/InvoiceBundle/Entity/AbstractInvoice.php
@@ -27,7 +27,7 @@ use Marello\Bundle\SalesBundle\Model\SalesChannelAwareInterface;
  * @ORM\Entity(repositoryClass="Marello\Bundle\InvoiceBundle\Entity\Repository\AbstractInvoiceRepository")
  * @ORM\InheritanceType("SINGLE_TABLE")
  * @ORM\DiscriminatorColumn(name="type", type="string")
- * @ORM\DiscriminatorMap({"invoice" = "Invoice", "creditmemo" = "Creditmemo"})
+ * @ORM\DiscriminatorMap({"invoice" = "Marello\Bundle\InvoiceBundle\Entity\Invoice", "creditmemo" = "Marello\Bundle\InvoiceBundle\Entity\Creditmemo"})
  * @ORM\Table(name="marello_invoice_invoice")
  * @Oro\Config(
  *      routeView="marello_invoice_invoice_view",

--- a/src/Marello/Bundle/InvoiceBundle/Entity/AbstractInvoiceItem.php
+++ b/src/Marello/Bundle/InvoiceBundle/Entity/AbstractInvoiceItem.php
@@ -31,7 +31,7 @@ use Oro\Bundle\OrganizationBundle\Entity\Ownership\AuditableOrganizationAwareTra
  * @ORM\Table(name="marello_invoice_invoice_item")
  * @ORM\InheritanceType("SINGLE_TABLE")
  * @ORM\DiscriminatorColumn(name="invoice_item_type", type="string")
- * @ORM\DiscriminatorMap({"invoiceitem" = "InvoiceItem", "creditmemoitem" = "CreditmemoItem"})
+ * @ORM\DiscriminatorMap({"invoiceitem" = "Marello\Bundle\InvoiceBundle\Entity\InvoiceItem", "creditmemoitem" = "Marello\Bundle\InvoiceBundle\Entity\CreditmemoItem"})
  * @ORM\HasLifecycleCallbacks()
  */
 abstract class AbstractInvoiceItem implements


### PR DESCRIPTION
Sometimes, `Oro\Bundle\EntitySerializedFieldsBundle\Migration\SerializedDataMigration` was failing with log : 
`ERROR: Entity class 'InvoiceItem' used in the discriminator map of class 'Marello\Bundle\InvoiceBundle\Entity\AbstractInvoiceItem' does not exist.`

This PR fixes it.