### PR TITLE
fix warning on classes not comply with psr-4 autoloading standard

### DIFF
--- a/src/Marello/Bundle/DemoDataBundle/Migrations/Data/Demo/ORM/LoadPdfConfiguration.php
+++ b/src/Marello/Bundle/DemoDataBundle/Migrations/Data/Demo/ORM/LoadPdfConfiguration.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Marello\Bundle\DemoDataBundle\Migrations\Data\Demo;
+namespace Marello\Bundle\DemoDataBundle\Migrations\Data\Demo\ORM;
 
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Persistence\ObjectManager;

--- a/src/Marello/Bundle/PaymentTermBundle/Migrations/Schema/v1_1/MarelloPaymentTermBundle.php
+++ b/src/Marello/Bundle/PaymentTermBundle/Migrations/Schema/v1_1/MarelloPaymentTermBundle.php
@@ -10,7 +10,7 @@ use Oro\Bundle\MigrationBundle\Migration\QueryBag;
 /**
  * @inheritDoc
  */
-class MarelloPaymentTermBundleInstaller implements Migration
+class MarelloPaymentTermBundle implements Migration
 {
     /**
      * @inheritDoc

--- a/src/Marello/Bundle/ProductBundle/Migrations/Schema/v1_6/UpdateEntityConfigQuery.php
+++ b/src/Marello/Bundle/ProductBundle/Migrations/Schema/v1_6/UpdateEntityConfigQuery.php
@@ -10,7 +10,7 @@ use Oro\Bundle\MigrationBundle\Migration\ParametrizedMigrationQuery;
 /**
  * Update entity config data using callback.
  */
-class UpdateEntityConfigDataQuery extends ParametrizedMigrationQuery
+class UpdateEntityConfigQuery extends ParametrizedMigrationQuery
 {
     /**
      * @var callable

--- a/src/Marello/Bundle/ShippingBundle/Migrations/Data/ORM/UpdateCurrentShipmentsWithOrganization.php
+++ b/src/Marello/Bundle/ShippingBundle/Migrations/Data/ORM/UpdateCurrentShipmentsWithOrganization.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Marello\Bundle\ShipmentBundle\Migrations\Data\ORM;
+namespace Marello\Bundle\ShippingBundle\Migrations\Data\ORM;
 
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Persistence\ObjectManager;

--- a/src/Marello/Bundle/ShippingBundle/Migrations/Schema/v1_2/MarelloShippingBundle.php
+++ b/src/Marello/Bundle/ShippingBundle/Migrations/Schema/v1_2/MarelloShippingBundle.php
@@ -10,7 +10,7 @@ use Oro\Bundle\MigrationBundle\Migration\QueryBag;
  * @SuppressWarnings(PHPMD.TooManyMethods)
  * @SuppressWarnings(PHPMD.ExcessiveClassLength)
  */
-class MarelloShippingBundleInstaller implements Migration
+class MarelloShippingBundle implements Migration
 {
     /**
      * {@inheritdoc}

--- a/src/Marello/Bundle/SupplierBundle/Migrations/Schema/v1_3/UpdateSupplierWithOrganization.php
+++ b/src/Marello/Bundle/SupplierBundle/Migrations/Schema/v1_3/UpdateSupplierWithOrganization.php
@@ -7,7 +7,7 @@ use Doctrine\DBAL\Schema\Schema;
 use Oro\Bundle\MigrationBundle\Migration\Migration;
 use Oro\Bundle\MigrationBundle\Migration\QueryBag;
 
-class MarelloSupplierBundle implements Migration
+class UpdateSupplierWithOrganization implements Migration
 {
     /**
      * {@inheritdoc}


### PR DESCRIPTION
Fix warning occurring after `composer install` , when requiring `marellocommerce/marello:3.2.2` : 
```
[...]
Generating optimized autoload files

Class Marello\Bundle\DemoDataBundle\Migrations\Data\Demo\LoadPdfConfiguration located in ./vendor/marellocommerce/marello/src/Marello/Bundle/DemoDataBundle/Migrations/Data/Demo/ORM/LoadPdfConfiguration.php does not comply with psr-4 autoloading standard. Skipping.

Class Marello\Bundle\PaymentTermBundle\Migrations\Schema\v1_1\MarelloPaymentTermBundleInstaller located in ./vendor/marellocommerce/marello/src/Marello/Bundle/PaymentTermBundle/Migrations/Schema/v1_1/MarelloPaymentTermBundle.php does not comply with psr-4 autoloading standard. Skipping.

Class Marello\Bundle\ProductBundle\Migrations\Schema\v1_6\UpdateEntityConfigDataQuery located in ./vendor/marellocommerce/marello/src/Marello/Bundle/ProductBundle/Migrations/Schema/v1_6/UpdateEntityConfigQuery.php does not comply with psr-4 autoloading standard. Skipping.

Class Marello\Bundle\ShipmentBundle\Migrations\Data\ORM\UpdateCurrentShipmentsWithOrganization located in ./vendor/marellocommerce/marello/src/Marello/Bundle/ShippingBundle/Migrations/Data/ORM/UpdateCurrentShipmentsWithOrganization.php does not comply with psr-4 autoloading standard. Skipping.

Class Marello\Bundle\ShippingBundle\Migrations\Schema\v1_2\MarelloShippingBundleInstaller located in ./vendor/marellocommerce/marello/src/Marello/Bundle/ShippingBundle/Migrations/Schema/v1_2/MarelloShippingBundle.php does not comply with psr-4 autoloading standard. Skipping.

Class Marello\Bundle\SupplierBundle\Migrations\Schema\v1_3\MarelloSupplierBundle located in ./vendor/marellocommerce/marello/src/Marello/Bundle/SupplierBundle/Migrations/Schema/v1_3/UpdateSupplierWithOrganization.php does not comply with psr-4 autoloading standard. Skipping.

[...]
```
